### PR TITLE
fixed setup.py UnicodeDecodeError for reading README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,10 @@
+import six
+
+if six.PY2:
+    # FileNotFoundError is only available since Python 3.3
+    FileNotFoundError = IOError
+    from io import open
+
 try:
     from setuptools import setup
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ except ImportError:
     from distutils.core import setup
 import sys
 
-with open('README.rst') as f:
+with open('README.rst', encoding="UTF-8") as f:
     readme = f.read()
 
 if sys.version_info < (3,3):


### PR DESCRIPTION
 in windows cp950 enviroment, pip install quantiphy raise UnicodeDecodeError.

log:
C:\Users\p\Desktop\New folder\quantiphy\quantiphy>pip install quantiphy
Collecting quantiphy
  Using cached https://files.pythonhosted.org/packages/a9/33/f6a1b5847d9f02ef88f926f1ec5dba5ff7239de11880da25cf5800c2c999/quantiphy-2.6.0.tar.gz
    ERROR: Command errored out with exit status 1:
     command: 'c:\python36-32\python.exe' -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\p\\AppData\\Local\\Temp\\pip-install-bcstr79g\\quantiphy\\setup.py'"'"'; __file__='"'"'C:\\Users\\p\\AppData\\Local\\Temp\\pip-install-bcstr79g\\quantiphy\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base 'C:\Users\p\AppData\Local\Temp\pip-install-bcstr79g\quantiphy\pip-egg-info'
         cwd: C:\Users\p\AppData\Local\Temp\pip-install-bcstr79g\quantiphy\
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\p\AppData\Local\Temp\pip-install-bcstr79g\quantiphy\setup.py", line 8, in <module>
        readme = f.read()
    UnicodeDecodeError: 'cp950' codec can't decode byte 0xe2 in position 10: illegal multibyte sequence
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

Adding encoding="UTF-8" to fix this issue.